### PR TITLE
Replacing Black Block Proxy Block

### DIFF
--- a/lua/autorun/server/sv_warden.lua
+++ b/lua/autorun/server/sv_warden.lua
@@ -146,7 +146,7 @@ function WARDEN.CheckIP( ip, callback, useCache )
 		return
 	end
 
-	http.Fetch( "http://proxy.mind-media.com/block/proxycheck.php?ip="..ip,
+	http.Fetch( "https://blackbox.ipinfo.app/lookup/"..ip,
 		function( info )
 			callback( info )
 


### PR DESCRIPTION
Black Block Proxy Block has gone poof. 

I've been working on a replacement using new ideas on how to map out proxy, hosting, and tor IPs. I have made it a drop-in replacement for the old Black Box Proxy Block site. Using the exact same "Y" or "N" for proxies. 

I'm hoping you will be will to try it out and let me know if you experience any problems.